### PR TITLE
feat: added 'read' flag in comments modal, to mark comment as readed, added additionalCommentFields to display custom columns in feedback table

### DIFF
--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -213,13 +213,18 @@ msgid "feedbacks_comments"
 msgstr "Commenti"
 
 #: components/manage/VFPanel/FeedbackComments
-# defaultMessage: {total} comments. {unreaded} to read.
+# defaultMessage: {total} comments.
 msgid "feedbacks_comments_button_open"
 msgstr "{total} commenti. {unreaded} da leggere."
 
 #: components/manage/VFPanel/FeedbackComments
-# defaultMessage: Readed
-msgid "feedbacks_comments_readed"
+# defaultMessage: Show comments to read.
+msgid "feedbacks_comments_filter_unread"
+msgstr "Mostra i commenti da leggere"
+
+#: components/manage/VFPanel/FeedbackComments
+# defaultMessage: Read
+msgid "feedbacks_comments_read"
 msgstr "Letto"
 
 #: components/manage/VFPanel/FeedbackComments

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -213,11 +213,17 @@ msgid "feedbacks_comments"
 msgstr "Commenti"
 
 #: components/manage/VFPanel/FeedbackComments
+# defaultMessage: All comments
+msgid "feedbacks_comments_all"
+msgstr ""
+
+#: components/manage/VFPanel/FeedbackComments
 # defaultMessage: {total} comments.
 msgid "feedbacks_comments_button_open"
 msgstr "{total} commenti. {unreaded} da leggere."
 
 #: components/manage/VFPanel/FeedbackComments
+#: components/manage/VFPanel/VFPanel
 # defaultMessage: Show comments to read.
 msgid "feedbacks_comments_filter_unread"
 msgstr "Mostra i commenti da leggere"
@@ -226,6 +232,36 @@ msgstr "Mostra i commenti da leggere"
 # defaultMessage: Read
 msgid "feedbacks_comments_read"
 msgstr "Letto"
+
+#: components/manage/VFPanel/FeedbackComments
+# defaultMessage: Set all as read.
+msgid "feedbacks_comments_set_all_read"
+msgstr "Imposta tutti come 'letti'"
+
+#: components/manage/VFPanel/FeedbackComments
+# defaultMessage: Set all as...
+msgid "feedbacks_comments_set_all_read_confirm_title"
+msgstr "Imposta tutti come..."
+
+#: components/manage/VFPanel/FeedbackComments
+# defaultMessage: Are you sure you want to set all visible comments as "read"?
+msgid "feedbacks_comments_set_all_read_confirm_title_read"
+msgstr "Sei sicuro di volere impostare tutti i commenti visibili come 'letti'?"
+
+#: components/manage/VFPanel/FeedbackComments
+# defaultMessage: Are you sure you want to set all visible comments as "unread"?
+msgid "feedbacks_comments_set_all_read_confirm_title_unread"
+msgstr "Sei sicuro di volere impostare tutti i commenti visibili come 'non letti'?"
+
+#: components/manage/VFPanel/FeedbackComments
+# defaultMessage: No
+msgid "feedbacks_comments_toggle_all_cancel"
+msgstr ""
+
+#: components/manage/VFPanel/FeedbackComments
+# defaultMessage: Yes
+msgid "feedbacks_comments_toggle_all_yes"
+msgstr "Si"
 
 #: components/manage/VFPanel/FeedbackComments
 # defaultMessage: Vote

--- a/locales/it/LC_MESSAGES/volto.po
+++ b/locales/it/LC_MESSAGES/volto.po
@@ -213,6 +213,16 @@ msgid "feedbacks_comments"
 msgstr "Commenti"
 
 #: components/manage/VFPanel/FeedbackComments
+# defaultMessage: {total} comments. {unreaded} to read.
+msgid "feedbacks_comments_button_open"
+msgstr "{total} commenti. {unreaded} da leggere."
+
+#: components/manage/VFPanel/FeedbackComments
+# defaultMessage: Readed
+msgid "feedbacks_comments_readed"
+msgstr "Letto"
+
+#: components/manage/VFPanel/FeedbackComments
 # defaultMessage: Vote
 msgid "feedbacks_comments_votes"
 msgstr "Voto"

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2024-07-30T08:32:41.891Z\n"
+"POT-Creation-Date: 2024-10-22T10:25:31.772Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -215,11 +215,17 @@ msgid "feedbacks_comments"
 msgstr ""
 
 #: components/manage/VFPanel/FeedbackComments
+# defaultMessage: All comments
+msgid "feedbacks_comments_all"
+msgstr ""
+
+#: components/manage/VFPanel/FeedbackComments
 # defaultMessage: {total} comments.
 msgid "feedbacks_comments_button_open"
 msgstr ""
 
 #: components/manage/VFPanel/FeedbackComments
+#: components/manage/VFPanel/VFPanel
 # defaultMessage: Show comments to read.
 msgid "feedbacks_comments_filter_unread"
 msgstr ""
@@ -227,6 +233,36 @@ msgstr ""
 #: components/manage/VFPanel/FeedbackComments
 # defaultMessage: Read
 msgid "feedbacks_comments_read"
+msgstr ""
+
+#: components/manage/VFPanel/FeedbackComments
+# defaultMessage: Set all as read.
+msgid "feedbacks_comments_set_all_read"
+msgstr ""
+
+#: components/manage/VFPanel/FeedbackComments
+# defaultMessage: Set all as...
+msgid "feedbacks_comments_set_all_read_confirm_title"
+msgstr ""
+
+#: components/manage/VFPanel/FeedbackComments
+# defaultMessage: Are you sure you want to set all visible comments as "read"?
+msgid "feedbacks_comments_set_all_read_confirm_title_read"
+msgstr ""
+
+#: components/manage/VFPanel/FeedbackComments
+# defaultMessage: Are you sure you want to set all visible comments as "unread"?
+msgid "feedbacks_comments_set_all_read_confirm_title_unread"
+msgstr ""
+
+#: components/manage/VFPanel/FeedbackComments
+# defaultMessage: No
+msgid "feedbacks_comments_toggle_all_cancel"
+msgstr ""
+
+#: components/manage/VFPanel/FeedbackComments
+# defaultMessage: Yes
+msgid "feedbacks_comments_toggle_all_yes"
 msgstr ""
 
 #: components/manage/VFPanel/FeedbackComments

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-"POT-Creation-Date: 2024-07-18T09:32:17.028Z\n"
+"POT-Creation-Date: 2024-07-30T08:32:41.891Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -215,13 +215,18 @@ msgid "feedbacks_comments"
 msgstr ""
 
 #: components/manage/VFPanel/FeedbackComments
-# defaultMessage: {total} comments. {unreaded} to read.
+# defaultMessage: {total} comments.
 msgid "feedbacks_comments_button_open"
 msgstr ""
 
 #: components/manage/VFPanel/FeedbackComments
-# defaultMessage: Readed
-msgid "feedbacks_comments_readed"
+# defaultMessage: Show comments to read.
+msgid "feedbacks_comments_filter_unread"
+msgstr ""
+
+#: components/manage/VFPanel/FeedbackComments
+# defaultMessage: Read
+msgid "feedbacks_comments_read"
 msgstr ""
 
 #: components/manage/VFPanel/FeedbackComments

--- a/locales/volto.pot
+++ b/locales/volto.pot
@@ -1,8 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Plone\n"
-
-"POT-Creation-Date: 2024-02-15T11:32:59.731Z\n"
+"POT-Creation-Date: 2024-07-18T09:32:17.028Z\n"
 "Last-Translator: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
 "MIME-Version: 1.0\n"
@@ -213,6 +212,16 @@ msgstr ""
 #: components/manage/VFPanel/VFPanel
 # defaultMessage: Comments
 msgid "feedbacks_comments"
+msgstr ""
+
+#: components/manage/VFPanel/FeedbackComments
+# defaultMessage: {total} comments. {unreaded} to read.
+msgid "feedbacks_comments_button_open"
+msgstr ""
+
+#: components/manage/VFPanel/FeedbackComments
+# defaultMessage: Readed
+msgid "feedbacks_comments_readed"
 msgstr ""
 
 #: components/manage/VFPanel/FeedbackComments

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -113,3 +113,19 @@ export function deleteFeedback(item) {
         })),
   };
 }
+
+/**
+ * DELETE_FEEDBACK action
+ * @module actions/getFeedbacks
+ */
+export const UPDATE_FEEDBACK = 'UPDATE_FEEDBACK';
+export function updateFeedback(parent_uid, item) {
+  return {
+    type: UPDATE_FEEDBACK,
+    request: {
+      op: 'patch',
+      path: '/@feedback/' + parent_uid,
+      data: item,
+    },
+  };
+}

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -82,20 +82,33 @@ export function getFeedbacks(data) {
  * @module actions/getFeedback
  */
 export const GET_FEEDBACK = 'GET_FEEDBACK';
-export function getFeedback(uid, subrequest) {
+export function getFeedback(uid, subrequest, search_params) {
+  const search = {
+    b_start: 0,
+    b_size: 25,
+    sort_on: 'date',
+    sort_order: 'descending',
+    show_unread: null,
+    ...search_params,
+  };
+  let path = `/@feedback/${uid}?b_start=${search.b_start}&b_size=${search.b_size}&sort_on=${search.sort_on}&sort_order=${search.sort_order}`;
+  if (search.show_unread) {
+    path += `&unread=true`;
+  }
+
   return {
     type: GET_FEEDBACK,
     subrequest,
     request: {
       op: 'get',
-      path: `/@feedback/${uid}`,
+      path,
     },
   };
 }
 
 /**
  * DELETE_FEEDBACK action
- * @module actions/getFeedbacks
+ * @module actions/deleteFeedback
  */
 export const DELETE_FEEDBACK = 'DELETE_FEEDBACK';
 export function deleteFeedback(item) {
@@ -115,8 +128,8 @@ export function deleteFeedback(item) {
 }
 
 /**
- * DELETE_FEEDBACK action
- * @module actions/getFeedbacks
+ * UPDATE_FEEDBACK action
+ * @module actions/updateFeedback
  */
 export const UPDATE_FEEDBACK = 'UPDATE_FEEDBACK';
 export function updateFeedback(parent_uid, item) {
@@ -126,6 +139,22 @@ export function updateFeedback(parent_uid, item) {
       op: 'patch',
       path: '/@feedback/' + parent_uid,
       data: item,
+    },
+  };
+}
+
+/**
+ * UPDATE_FEEDBACK action
+ * @module actions/updateFeedback
+ */
+export const UPDATE_FEEDBACK_LIST = 'UPDATE_FEEDBACK_LIST';
+export function updateFeedbackList(feedbacks) {
+  return {
+    type: UPDATE_FEEDBACK,
+    request: {
+      op: 'patch',
+      path: '/@feedback-list/',
+      data: feedbacks,
     },
   };
 }

--- a/src/components/manage/VFPanel/FeedbackComments.jsx
+++ b/src/components/manage/VFPanel/FeedbackComments.jsx
@@ -49,10 +49,10 @@ const messages = defineMessages({
     id: 'feedback_no_feedback',
     defaultMessage: 'No feedback provided',
   },
-  readed: { id: 'feedbacks_comments_readed', defaultMessage: 'Readed' },
+  read: { id: 'feedbacks_comments_read', defaultMessage: 'Read' },
   comments_button: {
     id: 'feedbacks_comments_button_open',
-    defaultMessage: '{total} comments. {unreaded} to read.',
+    defaultMessage: '{total} comments. {unread} to read.',
   },
 });
 
@@ -120,10 +120,10 @@ const FeedbackComments = ({ item, moment: Moment }) => {
     await dispatch(getFeedback(item.uid, item.uid));
   };
 
-  const toggleReaded = (comment, readed) => {
-    dispatch(updateFeedback(item.uid, { uid: comment.uid, readed: readed }));
+  const toggleRead = (comment, read) => {
+    dispatch(updateFeedback(item.uid, { uid: comment.uid, read: read }));
     let new_comments = [...comments];
-    new_comments.filter((c) => c.uid === comment.uid)[0].readed = readed;
+    new_comments.filter((c) => c.uid === comment.uid)[0].read = read;
     setComments(new_comments);
   };
 
@@ -153,12 +153,12 @@ const FeedbackComments = ({ item, moment: Moment }) => {
           className="open-feedback-comments"
           title={intl.formatMessage(messages.comments_button, {
             total: item.comments ?? 0,
-            unreaded: item.unreaded ?? 0,
+            unread: item.unread ?? 0,
           })}
         >
           {item.comments}
 
-          {item.unreaded > 0 && <span className="unreaded-items"></span>}
+          {item.unread > 0 && <span className="unread-items"></span>}
         </Button>
       }
       size="fullscreen"
@@ -196,7 +196,7 @@ const FeedbackComments = ({ item, moment: Moment }) => {
                   </Table.HeaderCell>
                 ))}
                 <Table.HeaderCell width={1} textAlign="center">
-                  {intl.formatMessage(messages.readed)}
+                  {intl.formatMessage(messages.read)}
                 </Table.HeaderCell>
               </Table.Row>
             </Table.Header>
@@ -208,7 +208,7 @@ const FeedbackComments = ({ item, moment: Moment }) => {
               )?.map((c) => (
                 <tr
                   key={generateFeedbackCommentUUID(c.date)}
-                  className={c.readed ? '' : 'comment-to-read'}
+                  className={c.read ? '' : 'comment-to-read'}
                 >
                   <Table.Cell textAlign="center">
                     <SIcon name="star" />
@@ -235,8 +235,8 @@ const FeedbackComments = ({ item, moment: Moment }) => {
                   ))}
                   <Table.Cell textAlign="center">
                     <Checkbox
-                      checked={c.readed}
-                      onChange={(e, data) => toggleReaded(c, data.checked)}
+                      checked={c.read}
+                      onChange={(e, data) => toggleRead(c, data.checked)}
                     />
                   </Table.Cell>
                 </tr>

--- a/src/components/manage/VFPanel/FeedbackComments.jsx
+++ b/src/components/manage/VFPanel/FeedbackComments.jsx
@@ -18,6 +18,7 @@ import clearSVG from '@plone/volto/icons/clear.svg';
 import { getFeedback, updateFeedback } from 'volto-feedback/actions';
 import 'semantic-ui-css/components/icon.css';
 import { generateFeedbackCommentUUID } from 'volto-feedback/helpers';
+import config from '@plone/volto/registry';
 
 const messages = defineMessages({
   close: {
@@ -134,6 +135,8 @@ const FeedbackComments = ({ item, moment: Moment }) => {
 
   const [comments, setComments] = useState([]);
 
+  const additionalColumns =
+    config.settings['volto-feedback'].additionalCommentFields ?? [];
   return (
     <Modal
       onClose={close}
@@ -154,6 +157,7 @@ const FeedbackComments = ({ item, moment: Moment }) => {
           })}
         >
           {item.comments}
+
           {item.unreaded > 0 && <span className="unreaded-items"></span>}
         </Button>
       }
@@ -186,6 +190,11 @@ const FeedbackComments = ({ item, moment: Moment }) => {
                 >
                   {intl.formatMessage(messages.date)}
                 </Table.HeaderCell>
+                {additionalColumns.map((column, i) => (
+                  <Table.HeaderCell width={1} key={i}>
+                    {column.label}
+                  </Table.HeaderCell>
+                ))}
                 <Table.HeaderCell width={1} textAlign="center">
                   {intl.formatMessage(messages.readed)}
                 </Table.HeaderCell>
@@ -219,6 +228,11 @@ const FeedbackComments = ({ item, moment: Moment }) => {
                   <Table.Cell>
                     {moment(c.date).format('DD/MM/YYYY HH:mm')}
                   </Table.Cell>
+                  {additionalColumns.map((column, i) => (
+                    <Table.Cell key={i + 'colcontent'}>
+                      {column.component ? column.component(c) : c[column.id]}
+                    </Table.Cell>
+                  ))}
                   <Table.Cell textAlign="center">
                     <Checkbox
                       checked={c.readed}

--- a/src/components/manage/VFPanel/FeedbackComments.jsx
+++ b/src/components/manage/VFPanel/FeedbackComments.jsx
@@ -121,7 +121,7 @@ const FeedbackComments = ({ item, moment: Moment }) => {
   };
 
   const toggleRead = (comment, read) => {
-    dispatch(updateFeedback(item.uid, { uid: comment.uid, read: read }));
+    dispatch(updateFeedback(comment.id, { read: read }));
     let new_comments = [...comments];
     new_comments.filter((c) => c.uid === comment.uid)[0].read = read;
     setComments(new_comments);

--- a/src/components/manage/VFPanel/FeedbackComments.jsx
+++ b/src/components/manage/VFPanel/FeedbackComments.jsx
@@ -1,25 +1,27 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { useIntl, defineMessages } from 'react-intl';
+import { useSelector, useDispatch } from 'react-redux';
 import {
   Modal,
   Button,
   Table,
-  Label,
-  Segment,
   Icon as SIcon,
   Loader,
   Form,
   Checkbox,
+  Confirm,
 } from 'semantic-ui-react';
-import orderBy from 'lodash/orderBy';
+import { Pagination } from '@plone/volto/components';
 import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
-import { useSelector, useDispatch } from 'react-redux';
-import { Icon } from '@plone/volto/components';
-import clearSVG from '@plone/volto/icons/clear.svg';
-import { getFeedback, updateFeedback } from 'volto-feedback/actions';
-import 'semantic-ui-css/components/icon.css';
+import {
+  getFeedback,
+  updateFeedback,
+  updateFeedbackList,
+} from 'volto-feedback/actions';
 import { generateFeedbackCommentUUID } from 'volto-feedback/helpers';
 import config from '@plone/volto/registry';
+import 'semantic-ui-css/components/icon.css';
+import './feedback-comments.css';
 
 const messages = defineMessages({
   close: {
@@ -59,6 +61,32 @@ const messages = defineMessages({
     id: 'feedbacks_comments_filter_unread',
     defaultMessage: 'Show comments to read.',
   },
+  set_all_read: {
+    id: 'feedbacks_comments_set_all_read',
+    defaultMessage: 'Set all as read.',
+  },
+  all: {
+    id: 'feedbacks_comments_all',
+    defaultMessage: 'All comments',
+  },
+  yes: {
+    id: 'feedbacks_comments_toggle_all_yes',
+    defaultMessage: 'Yes',
+  },
+  set_all_read_confirm_title: {
+    id: 'feedbacks_comments_set_all_read_confirm_title',
+    defaultMessage: 'Set all as...',
+  },
+  set_all_read_confirm_title_read: {
+    id: 'feedbacks_comments_set_all_read_confirm_title_read',
+    defaultMessage:
+      'Are you sure you want to set all visible comments as "read"?',
+  },
+  set_all_read_confirm_title_unread: {
+    id: 'feedbacks_comments_set_all_read_confirm_title_unread',
+    defaultMessage:
+      'Are you sure you want to set all visible comments as "unread"?',
+  },
 });
 
 const ReadMore = ({ children, intl }) => {
@@ -94,44 +122,21 @@ const ReadMore = ({ children, intl }) => {
 
 const FeedbackComments = ({ item, moment: Moment }) => {
   const intl = useIntl();
+  const dispatch = useDispatch();
   const moment = Moment.default;
+
   const [open, setOpen] = useState(false);
-  const [sortOrder, setSortOrder] = useState('descending');
-  const [sortOn, setSortOn] = useState('date');
+  const [sort, setSort] = useState({ on: 'date', order: 'descending' });
+  const [currentPage, setCurrentPage] = useState(0);
   const [filters, setFilters] = useState({});
+  const [checkAllRead, setCheckAllRead] = useState(false);
+  const [modalConfirmOpen, setModalConfirmOpen] = useState(false);
+  const b_size = 25;
   moment.locale(intl.locale);
 
   const feedbackCommentsResults = useSelector((state) => {
     return state.getFeedback?.subrequests?.[item?.uid];
   });
-  const dispatch = useDispatch();
-
-  const close = () => {
-    setOpen(false);
-  };
-
-  const changeSort = (column) => {
-    if (sortOn === column) {
-      if (sortOrder === 'ascending') {
-        setSortOrder('descending');
-      } else {
-        setSortOrder('ascending');
-      }
-    } else {
-      setSortOn(column);
-    }
-  };
-
-  const loadCommentsData = async () => {
-    await dispatch(getFeedback(item.uid, item.uid));
-  };
-
-  const toggleRead = (comment, read) => {
-    dispatch(updateFeedback(comment.id, { read: read }));
-    let new_comments = [...comments];
-    new_comments.filter((c) => c.id === comment.id)[0].read = read;
-    setComments(new_comments);
-  };
 
   useEffect(() => {
     if (feedbackCommentsResults?.loaded) {
@@ -139,148 +144,243 @@ const FeedbackComments = ({ item, moment: Moment }) => {
     }
   }, [feedbackCommentsResults]);
 
+  const close = () => {
+    setOpen(false);
+  };
+
+  const changeSort = (column) => {
+    if (sort.on === column) {
+      if (sort.order === 'ascending') {
+        setSort({ ...sort, order: 'descending' });
+      } else {
+        setSort({ ...sort, order: 'ascending' });
+      }
+    } else {
+      setSort({ ...sort, on: column, order: 'ascending' });
+    }
+  };
+
+  const loadCommentsData = async () => {
+    const b_start = currentPage * b_size;
+    await dispatch(
+      getFeedback(item.uid, item.uid, {
+        b_start,
+        b_size,
+        sort_on: sort.on,
+        sort_order: sort.order,
+        show_unread: filters.unread,
+      }),
+    );
+  };
+
+  //toggle READ on single comment
+  const toggleRead = (comment, read) => {
+    dispatch(updateFeedback(comment.id, { read: read }));
+    let new_comments = [...comments];
+    new_comments.filter((c) => c.id === comment.id)[0].read = read;
+    setComments(new_comments);
+  };
+
   const [comments, setComments] = useState([]);
 
   const additionalColumns =
     config.settings['volto-feedback'].additionalCommentFields ?? [];
 
-  return (
-    <Modal
-      onClose={close}
-      onOpen={loadCommentsData}
-      open={open}
-      id="feedback-comments-modal"
-      trigger={
-        <Button
-          size="mini"
-          type="button"
-          onClick={() => {
-            setOpen(true);
-          }}
-          className="open-feedback-comments"
-          title={intl.formatMessage(messages.comments_button, {
-            total: item.comments ?? 0,
-          })}
-        >
-          {item.comments}
+  const toggleAllRead = (read) => {
+    const feedbacks = comments.reduce((acc, c) => {
+      acc[c.id] = { read };
+      return acc;
+    }, {});
+    dispatch(updateFeedbackList(feedbacks));
+    loadCommentsData();
+  };
 
-          {item.has_unread && <span className="unread-items"></span>}
-        </Button>
-      }
-      size="fullscreen"
-    >
-      <Modal.Header>{item?.title}</Modal.Header>
-      <Modal.Content>
-        {feedbackCommentsResults?.loading && (
-          <Loader active className="workaround" inline="centered" />
-        )}
-        {feedbackCommentsResults?.loaded && (
-          <>
-            <Form className="search-comments-form">
-              <Checkbox
-                slider
-                label={intl.formatMessage(messages.filter_unread)}
-                onChange={(e, data) =>
-                  setFilters({ ...filters, unread: data.checked })
-                }
-                checked={filters.unread}
-              />
-            </Form>
-            <Table compact attached fixed striped sortable>
-              <Table.Header>
-                <Table.Row>
-                  <Table.HeaderCell
-                    width={1}
-                    textAlign="center"
-                    sorted={sortOn === 'vote' ? sortOrder : null}
-                    onClick={() => changeSort('vote')}
-                  >
-                    {intl.formatMessage(messages.vote)}
-                  </Table.HeaderCell>
-                  <Table.HeaderCell width={8}>
-                    {intl.formatMessage(messages.comment)}
-                  </Table.HeaderCell>
-                  <Table.HeaderCell
-                    width={2}
-                    sorted={sortOn === 'date' ? sortOrder : null}
-                    onClick={() => changeSort('date')}
-                  >
-                    {intl.formatMessage(messages.date)}
-                  </Table.HeaderCell>
-                  {additionalColumns.map((column, i) => (
-                    <Table.HeaderCell width={1} key={i}>
-                      {column.label}
+  useEffect(() => {
+    loadCommentsData();
+  }, [currentPage, sort, filters]);
+
+  return (
+    <>
+      <Modal
+        onClose={close}
+        onOpen={loadCommentsData}
+        open={open}
+        id="feedback-comments-modal"
+        trigger={
+          <Button
+            size="mini"
+            type="button"
+            onClick={() => {
+              setOpen(true);
+            }}
+            className="open-feedback-comments"
+            title={intl.formatMessage(messages.comments_button, {
+              total: item.comments ?? 0,
+            })}
+          >
+            {item.comments}
+
+            {item.has_unread && <span className="unread-items"></span>}
+          </Button>
+        }
+        size="fullscreen"
+      >
+        <Modal.Header>{item?.title}</Modal.Header>
+        <Modal.Content>
+          {feedbackCommentsResults?.loading && (
+            <Loader active className="workaround" inline="centered" />
+          )}
+          {feedbackCommentsResults?.loaded && (
+            <>
+              <Form className="search-comments-form">
+                <Checkbox
+                  slider
+                  label={intl.formatMessage(messages.filter_unread)}
+                  onChange={(e, data) =>
+                    setFilters({ ...filters, unread: data.checked })
+                  }
+                  checked={filters.unread}
+                />
+              </Form>
+
+              <Table compact attached fixed striped sortable>
+                <Table.Header>
+                  <Table.Row>
+                    <Table.HeaderCell
+                      width={1}
+                      textAlign="center"
+                      sorted={sort.on === 'vote' ? sort.order : null}
+                      onClick={() => changeSort('vote')}
+                    >
+                      {intl.formatMessage(messages.vote)}
                     </Table.HeaderCell>
-                  ))}
-                  <Table.HeaderCell width={1} textAlign="center">
-                    {intl.formatMessage(messages.read)}
-                  </Table.HeaderCell>
-                </Table.Row>
-              </Table.Header>
-              <Table.Body>
-                {orderBy(
-                  comments.filter((c) => {
-                    let show = true;
-                    Object.keys(filters).forEach((f) => {
-                      if (f == 'unread') {
-                        if (filters[f] && c.read) {
-                          show = false;
-                        }
-                      } else if (c[f] != filters[f]) {
-                        show = false;
-                      }
-                    });
-                    return show;
-                  }),
-                  sortOn,
-                  sortOrder === 'ascending' ? 'asc' : 'desc',
-                )?.map((c) => (
-                  <tr
-                    key={generateFeedbackCommentUUID(c.date)}
-                    className={c.read ? '' : 'comment-to-read'}
-                  >
-                    <Table.Cell textAlign="center">
-                      <SIcon name="star" />
-                      {Math.fround(c.vote)}
-                    </Table.Cell>
-                    <Table.Cell>
-                      <div className="feedback-answer">{c.answer}</div>
-                      <div className="feedback-comment">
-                        <ReadMore intl={intl}>{c.comment}</ReadMore>
-                        {!c.answer && !c.comment && (
-                          <div className="feedback-no-feedback">
-                            {intl.formatMessage(messages.no_feedback)}
-                          </div>
-                        )}
-                      </div>
-                    </Table.Cell>
-                    <Table.Cell>
-                      {moment(c.date).format('DD/MM/YYYY HH:mm')}
-                    </Table.Cell>
+                    <Table.HeaderCell width={8}>
+                      {intl.formatMessage(messages.comment)}
+                    </Table.HeaderCell>
+                    <Table.HeaderCell
+                      width={2}
+                      sorted={sort.on === 'date' ? sort.order : null}
+                      onClick={() => changeSort('date')}
+                    >
+                      {intl.formatMessage(messages.date)}
+                    </Table.HeaderCell>
                     {additionalColumns.map((column, i) => (
-                      <Table.Cell key={i + 'colcontent'}>
-                        {column.component ? column.component(c) : c[column.id]}
-                      </Table.Cell>
+                      <Table.HeaderCell width={1} key={i}>
+                        {column.label}
+                      </Table.HeaderCell>
                     ))}
-                    <Table.Cell textAlign="center">
-                      <Checkbox
-                        checked={c.read}
-                        onChange={(e, data) => toggleRead(c, data.checked)}
-                      />
-                    </Table.Cell>
-                  </tr>
-                ))}
-              </Table.Body>
-            </Table>
-          </>
-        )}
-      </Modal.Content>
-      <Modal.Actions>
-        <Button color="black" onClick={close}>
-          {intl.formatMessage(messages.close)}
-        </Button>
-      </Modal.Actions>
-    </Modal>
+                    <Table.HeaderCell
+                      width={1}
+                      textAlign="center"
+                      id="read-head-col"
+                    >
+                      {intl.formatMessage(messages.read)}
+
+                      <div className="ui fitted checkbox">
+                        <input
+                          type="checkbox"
+                          title={intl.formatMessage(messages.set_all_read)}
+                          checked={checkAllRead}
+                          onChange={(e) => {
+                            const read = e.target.checked;
+                            setCheckAllRead(read);
+                            setModalConfirmOpen(true);
+                          }}
+                        />
+                        <label></label>
+                      </div>
+                    </Table.HeaderCell>
+                  </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                  {comments?.map((c) => (
+                    <tr
+                      key={generateFeedbackCommentUUID(c.date)}
+                      className={c.read ? '' : 'comment-to-read'}
+                    >
+                      <Table.Cell textAlign="center">
+                        <SIcon name="star" />
+                        {Math.fround(c.vote)}
+                      </Table.Cell>
+                      <Table.Cell>
+                        <div className="feedback-answer">{c.answer}</div>
+                        <div className="feedback-comment">
+                          <ReadMore intl={intl}>{c.comment}</ReadMore>
+                          {!c.answer && !c.comment && (
+                            <div className="feedback-no-feedback">
+                              {intl.formatMessage(messages.no_feedback)}
+                            </div>
+                          )}
+                        </div>
+                      </Table.Cell>
+                      <Table.Cell>
+                        {moment(c.date).format('DD/MM/YYYY HH:mm')}
+                      </Table.Cell>
+                      {additionalColumns.map((column, i) => (
+                        <Table.Cell key={i + 'colcontent'}>
+                          {column.component
+                            ? column.component(c)
+                            : c[column.id]}
+                        </Table.Cell>
+                      ))}
+                      <Table.Cell textAlign="center">
+                        <Checkbox
+                          checked={c.read}
+                          onChange={(e, data) => toggleRead(c, data.checked)}
+                        />
+                      </Table.Cell>
+                    </tr>
+                  ))}
+                </Table.Body>
+              </Table>
+              <div className="contents-pagination">
+                <Pagination
+                  current={currentPage}
+                  total={Math.ceil(feedbackCommentsResults?.total / b_size)}
+                  pageSize={b_size}
+                  onChangePage={(e, p) => {
+                    setCurrentPage(p.value);
+                  }}
+                  //  pageSizes={[b_size, intl.formatMessage(messages.all)]}
+                  // onChangePageSize={(e, s) => setB_size(s.value)}
+                />
+              </div>
+            </>
+          )}
+        </Modal.Content>
+        <Modal.Actions>
+          <Button color="black" onClick={close}>
+            {intl.formatMessage(messages.close)}
+          </Button>
+        </Modal.Actions>
+      </Modal>
+
+      <Confirm
+        open={modalConfirmOpen}
+        confirmButton={intl.formatMessage(messages.yes)}
+        header={intl.formatMessage(messages.set_all_read_confirm_title)}
+        content={
+          <div className="content">
+            <p>
+              {checkAllRead
+                ? intl.formatMessage(messages.set_all_read_confirm_title_read)
+                : intl.formatMessage(
+                    messages.set_all_read_confirm_title_unread,
+                  )}
+            </p>
+          </div>
+        }
+        onCancel={() => {
+          setModalConfirmOpen(false);
+          setCheckAllRead(!checkAllRead);
+        }}
+        onConfirm={() => {
+          toggleAllRead(checkAllRead);
+          setModalConfirmOpen(false);
+        }}
+        size="medium"
+      />
+    </>
   );
 };
 

--- a/src/components/manage/VFPanel/FeedbackComments.jsx
+++ b/src/components/manage/VFPanel/FeedbackComments.jsx
@@ -73,6 +73,10 @@ const messages = defineMessages({
     id: 'feedbacks_comments_toggle_all_yes',
     defaultMessage: 'Yes',
   },
+  cancelButton: {
+    id: 'feedbacks_comments_toggle_all_cancel',
+    defaultMessage: 'No',
+  },
   set_all_read_confirm_title: {
     id: 'feedbacks_comments_set_all_read_confirm_title',
     defaultMessage: 'Set all as...',
@@ -358,6 +362,7 @@ const FeedbackComments = ({ item, moment: Moment }) => {
       <Confirm
         open={modalConfirmOpen}
         confirmButton={intl.formatMessage(messages.yes)}
+        cancelButton={intl.formatMessage(messages.cancel)}
         header={intl.formatMessage(messages.set_all_read_confirm_title)}
         content={
           <div className="content">

--- a/src/components/manage/VFPanel/FeedbackComments.jsx
+++ b/src/components/manage/VFPanel/FeedbackComments.jsx
@@ -52,7 +52,7 @@ const messages = defineMessages({
   read: { id: 'feedbacks_comments_read', defaultMessage: 'Read' },
   comments_button: {
     id: 'feedbacks_comments_button_open',
-    defaultMessage: '{total} comments. {unread} to read.',
+    defaultMessage: '{total} comments.',
   },
 });
 
@@ -123,7 +123,7 @@ const FeedbackComments = ({ item, moment: Moment }) => {
   const toggleRead = (comment, read) => {
     dispatch(updateFeedback(comment.id, { read: read }));
     let new_comments = [...comments];
-    new_comments.filter((c) => c.uid === comment.uid)[0].read = read;
+    new_comments.filter((c) => c.id === comment.id)[0].read = read;
     setComments(new_comments);
   };
 
@@ -137,6 +137,7 @@ const FeedbackComments = ({ item, moment: Moment }) => {
 
   const additionalColumns =
     config.settings['volto-feedback'].additionalCommentFields ?? [];
+
   return (
     <Modal
       onClose={close}
@@ -153,12 +154,11 @@ const FeedbackComments = ({ item, moment: Moment }) => {
           className="open-feedback-comments"
           title={intl.formatMessage(messages.comments_button, {
             total: item.comments ?? 0,
-            unread: item.unread ?? 0,
           })}
         >
           {item.comments}
 
-          {item.unread > 0 && <span className="unread-items"></span>}
+          {item.has_unread && <span className="unread-items"></span>}
         </Button>
       }
       size="fullscreen"

--- a/src/components/manage/VFPanel/FeedbackComments.jsx
+++ b/src/components/manage/VFPanel/FeedbackComments.jsx
@@ -329,7 +329,11 @@ const FeedbackComments = ({ item, moment: Moment }) => {
                       ))}
                       <Table.Cell textAlign="center">
                         <Checkbox
-                          checked={c.read}
+                          checked={
+                            typeof c.read == 'string'
+                              ? c.read === 'true'
+                              : c.read
+                          }
                           onChange={(e, data) => toggleRead(c, data.checked)}
                         />
                       </Table.Cell>
@@ -362,7 +366,7 @@ const FeedbackComments = ({ item, moment: Moment }) => {
       <Confirm
         open={modalConfirmOpen}
         confirmButton={intl.formatMessage(messages.yes)}
-        cancelButton={intl.formatMessage(messages.cancel)}
+        cancelButton={intl.formatMessage(messages.cancelButton)}
         header={intl.formatMessage(messages.set_all_read_confirm_title)}
         content={
           <div className="content">
@@ -383,7 +387,7 @@ const FeedbackComments = ({ item, moment: Moment }) => {
           toggleAllRead(checkAllRead);
           setModalConfirmOpen(false);
         }}
-        size="medium"
+        size="small"
       />
     </>
   );

--- a/src/components/manage/VFPanel/VFPanel.jsx
+++ b/src/components/manage/VFPanel/VFPanel.jsx
@@ -557,7 +557,7 @@ const VFPanel = ({ moment: Moment, toastify }) => {
               onConfirm={async () => {
                 await resetSelectedFeedbacks();
               }}
-              size=""
+              size="small"
             />
           )}
         </Container>

--- a/src/components/manage/VFPanel/VFPanel.jsx
+++ b/src/components/manage/VFPanel/VFPanel.jsx
@@ -125,6 +125,10 @@ const messages = defineMessages({
     id: 'feedbacks_loading',
     defaultMessage: 'Loading...',
   },
+  filter_unread: {
+    id: 'feedbacks_comments_filter_unread',
+    defaultMessage: 'Show comments to read.',
+  },
 });
 const VFPanel = ({ moment: Moment, toastify }) => {
   const intl = useIntl();
@@ -142,7 +146,8 @@ const VFPanel = ({ moment: Moment, toastify }) => {
 
   const [currentPage, setCurrentPage] = useState(0);
   const [searchableText, setSearchableText] = useState('');
-  const [text, setText] = useState('');
+
+  const [filters, setFilters] = useState({ text: '' });
   const [isClient, setIsClient] = useState(false);
   const [showConfirmDelete, setShowConfirmDelete] = useState(false);
 
@@ -150,7 +155,7 @@ const VFPanel = ({ moment: Moment, toastify }) => {
 
   useEffect(() => {
     const delayDebounceFn = setTimeout(() => {
-      setText(searchableText);
+      setFilters({ ...filters, text: searchableText });
       // Send Axios request here
     }, 1200);
 
@@ -184,7 +189,9 @@ const VFPanel = ({ moment: Moment, toastify }) => {
         b_start: currentPage * (isNaN(b_size) ? 10000000 : b_size),
         sort_on,
         sort_order,
-        title: text && text.length > 0 ? text + '*' : null,
+        title:
+          filters.text && filters.text.length > 0 ? filters.text + '*' : null,
+        has_unread: filters.has_unread,
       }),
     );
   };
@@ -192,7 +199,7 @@ const VFPanel = ({ moment: Moment, toastify }) => {
   useEffect(() => {
     doSearch();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [b_size, currentPage, text, sort_on, sort_order]);
+  }, [b_size, currentPage, sort_on, sort_order, filters]);
 
   const changeSort = (column) => {
     if (sort_on === column) {
@@ -282,15 +289,27 @@ const VFPanel = ({ moment: Moment, toastify }) => {
                 </Message>
               )}
               <Form className="search-form">
-                <Input
-                  fluid
-                  icon="search"
-                  value={searchableText}
-                  onChange={(e) => {
-                    setSearchableText(e.target.value);
-                  }}
-                  placeholder={intl.formatMessage(messages.filter_title)}
-                />
+                <div className="search-filter">
+                  <Input
+                    fluid
+                    icon="search"
+                    value={searchableText}
+                    onChange={(e) => {
+                      setSearchableText(e.target.value);
+                    }}
+                    placeholder={intl.formatMessage(messages.filter_title)}
+                  />
+                </div>
+                <div className="search-filter read">
+                  <Checkbox
+                    slider
+                    label={intl.formatMessage(messages.filter_unread)}
+                    onChange={(e, data) =>
+                      setFilters({ ...filters, has_unread: data.checked })
+                    }
+                    checked={filters.has_unread}
+                  />
+                </div>
               </Form>
               <Table
                 selectable

--- a/src/components/manage/VFPanel/VFPanel.jsx
+++ b/src/components/manage/VFPanel/VFPanel.jsx
@@ -305,7 +305,10 @@ const VFPanel = ({ moment: Moment, toastify }) => {
                     slider
                     label={intl.formatMessage(messages.filter_unread)}
                     onChange={(e, data) =>
-                      setFilters({ ...filters, has_unread: data.checked })
+                      setFilters({
+                        ...filters,
+                        has_unread: data.checked === true ? true : null,
+                      })
                     }
                     checked={filters.has_unread}
                   />

--- a/src/components/manage/VFPanel/VFPanelMenu.jsx
+++ b/src/components/manage/VFPanel/VFPanelMenu.jsx
@@ -136,7 +136,7 @@ const VFPanelMenu = ({ toastify, doSearch, can_delete_feedbacks }) => {
         }
         onCancel={() => setOpenConfirm(false)}
         onConfirm={deleteAll}
-        size=""
+        size="small"
       />
     </Menu>
   );

--- a/src/components/manage/VFPanel/feedback-comments.css
+++ b/src/components/manage/VFPanel/feedback-comments.css
@@ -1,0 +1,7 @@
+#feedback-comments-modal .contents-pagination .right.menu {
+  display: none;
+}
+
+#feedback-comments-modal #read-head-col .ui.checkbox {
+  margin-left: 0.5rem;
+}

--- a/src/components/manage/VFPanel/vf-panel.css
+++ b/src/components/manage/VFPanel/vf-panel.css
@@ -112,6 +112,12 @@
   font-weight: 600;
 }
 
+#feedback-comments-modal .ui.form.search-comments-form {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 1rem;
+}
+
 #feedback-comments-modal .vote-label .icon {
   margin: 0;
 }

--- a/src/components/manage/VFPanel/vf-panel.css
+++ b/src/components/manage/VFPanel/vf-panel.css
@@ -14,6 +14,9 @@
 #page-feedbacks .ui.sortable.table thead th.ascending:after {
   display: none;
 }
+#page-feedbacks .ui.table thead th.center.aligned .button {
+  justify-content: center;
+}
 
 #page-feedbacks .ui.table.sortable thead th.sorted .button:after {
   width: 0px;
@@ -61,6 +64,19 @@
   border: 1px solid #995c00;
 }
 
+#page-feedbacks .ui.button.open-feedback-comments {
+  position: relative;
+}
+#page-feedbacks .ui.button.open-feedback-comments .unreaded-items {
+  position: absolute;
+  width: 0.5rem;
+  height: 0.5rem;
+  background-color: #ff7f50;
+  border-radius: 100%;
+  top: -0.25rem;
+  right: -0.25rem;
+}
+
 #page-feedbacks .ui.form.search-form .ui.fluid.input {
   justify-content: flex-end;
   margin-bottom: 0.5rem;
@@ -100,17 +116,20 @@
   margin: 0;
 }
 
-#feedback-comments-modal .feedback-answer {
-  font-weight: 600;
-}
-
 #feedback-comments-modal .feedback-comment {
   font-style: italic;
+  font-size: 0.9rem;
+  font-weight: 300;
 }
 
 #feedback-comments-modal .feedback-no-feedback {
   color: rgba(0, 0, 0, 0.2);
   font-style: italic;
+}
+
+#feedback-comments-modal tr.comment-to-read,
+#feedback-comments-modal tr.comment-to-read .feedback-comment {
+  font-weight: 600;
 }
 
 .ui.dimmer .ui.workaround.loader:before {

--- a/src/components/manage/VFPanel/vf-panel.css
+++ b/src/components/manage/VFPanel/vf-panel.css
@@ -77,13 +77,36 @@
   right: -0.25rem;
 }
 
+#page-feedbacks .ui.form.search-form {
+  display: flex;
+  justify-content: space-between;
+  vertical-align: middle;
+  flex-wrap: wrap;
+  column-gap: 1rem;
+}
+
+#page-feedbacks .ui.form.search-form .search-filter {
+  flex: 1 1 auto;
+  min-width: 25rem;
+}
+
+#page-feedbacks .ui.form.search-form .search-filter.read {
+  display: flex;
+  vertical-align: middle;
+  justify-content: flex-end;
+}
+#page-feedbacks .ui.form.search-form .search-filter.read .ui.ui.checkbox {
+  margin-top: 1.2rem;
+  margin-bottom: 1.2rem;
+}
+
 #page-feedbacks .ui.form.search-form .ui.fluid.input {
   justify-content: flex-end;
   margin-bottom: 0.5rem;
 }
 
 #page-feedbacks .ui.form.search-form .ui.fluid.input input {
-  max-width: 23rem;
+  max-width: 25rem;
 }
 
 #page-feedbacks .ui.message.selected-items {

--- a/src/components/manage/VFPanel/vf-panel.css
+++ b/src/components/manage/VFPanel/vf-panel.css
@@ -67,7 +67,7 @@
 #page-feedbacks .ui.button.open-feedback-comments {
   position: relative;
 }
-#page-feedbacks .ui.button.open-feedback-comments .unreaded-items {
+#page-feedbacks .ui.button.open-feedback-comments .unread-items {
   position: absolute;
   width: 0.5rem;
   height: 0.5rem;

--- a/src/index.js
+++ b/src/index.js
@@ -94,6 +94,15 @@ export default function applyConfig(config) {
         pane: CommentsStep,
       },
     ],
+
+    additionalCommentFields: [
+      /*
+      Additional columns to display in comments table, for example if i customize steps.
+      If component attribute is undefined, the simple value is displayed.
+      Example:
+      { id: 'email', label: 'Email', component: null },
+      */
+    ],
   };
 
   config.settings.appExtras = [

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import {
   getFeedback,
   getFeedbacks,
   deleteFeedback,
+  updateFeedback,
 } from 'volto-feedback/reducers';
 import { CommentsStep, AnswersStep } from 'volto-feedback/components';
 import {
@@ -25,6 +26,7 @@ export {
   deleteFeedback,
   resetSubmitFeedback,
   resetDeleteFeedback,
+  updateFeedback,
 } from 'volto-feedback/actions';
 export {
   getFeedbackFormSteps,
@@ -54,8 +56,8 @@ export {
 } from 'volto-feedback/components/manage';
 
 export default function applyConfig(config) {
-  config.settings.loadables['GoogleReCaptcha'] = loadable(() =>
-    import('react-google-recaptcha-v3'),
+  config.settings.loadables['GoogleReCaptcha'] = loadable(
+    () => import('react-google-recaptcha-v3'),
   );
 
   config.settings.nonContentRoutes = [
@@ -71,6 +73,7 @@ export default function applyConfig(config) {
     getFeedback,
     getFeedbacks,
     deleteFeedback,
+    updateFeedback,
   };
 
   config.settings['volto-feedback'] = {

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import {
   getFeedbacks,
   deleteFeedback,
   updateFeedback,
+  updateFeedbackList,
 } from 'volto-feedback/reducers';
 import { CommentsStep, AnswersStep } from 'volto-feedback/components';
 import {
@@ -27,6 +28,7 @@ export {
   resetSubmitFeedback,
   resetDeleteFeedback,
   updateFeedback,
+  updateFeedbackList,
 } from 'volto-feedback/actions';
 export {
   getFeedbackFormSteps,
@@ -56,8 +58,8 @@ export {
 } from 'volto-feedback/components/manage';
 
 export default function applyConfig(config) {
-  config.settings.loadables['GoogleReCaptcha'] = loadable(
-    () => import('react-google-recaptcha-v3'),
+  config.settings.loadables['GoogleReCaptcha'] = loadable(() =>
+    import('react-google-recaptcha-v3'),
   );
 
   config.settings.nonContentRoutes = [
@@ -74,6 +76,7 @@ export default function applyConfig(config) {
     getFeedbacks,
     deleteFeedback,
     updateFeedback,
+    updateFeedbackList,
   };
 
   config.settings['volto-feedback'] = {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -8,7 +8,9 @@ import {
   DELETE_FEEDBACK,
   RESET_DELETE_FEEDBACK,
   UPDATE_FEEDBACK,
+  UPDATE_FEEDBACK_LIST,
 } from 'volto-feedback/actions';
+import { omit } from 'lodash';
 
 const RESET_GET_FEEDBACK = 'RESET_GET_FEEDBACK';
 
@@ -211,7 +213,6 @@ export const getFeedback = (state = initialState, action = {}) => {
                 ...(state.subrequests[action.subrequest] || {
                   items: [],
                   total: 0,
-                  batching: {},
                 }),
                 error: null,
                 loaded: false,
@@ -238,7 +239,6 @@ export const getFeedback = (state = initialState, action = {}) => {
                 total: action.result.items_total,
                 loaded: true,
                 loading: false,
-                batching: { ...action.result.batching },
               },
             },
           }
@@ -249,7 +249,6 @@ export const getFeedback = (state = initialState, action = {}) => {
             total: action.result.items_total,
             loaded: true,
             loading: false,
-            batching: { ...action.result.batching },
           };
     case `${GET_FEEDBACK}_FAIL`:
       return action.subrequest
@@ -263,7 +262,6 @@ export const getFeedback = (state = initialState, action = {}) => {
                 total: 0,
                 loading: false,
                 loaded: false,
-                batching: {},
               },
             },
           }
@@ -274,7 +272,6 @@ export const getFeedback = (state = initialState, action = {}) => {
             total: 0,
             loading: false,
             loaded: false,
-            batching: {},
           };
     case RESET_GET_FEEDBACK:
       return action.subrequest
@@ -427,6 +424,81 @@ export const updateFeedback = (state = initialState, action = {}) => {
             },
           };
     case `${UPDATE_FEEDBACK}_FAIL`:
+      return action.subrequest
+        ? {
+            ...state,
+            subrequests: {
+              ...state.subrequests,
+              [action.subrequest]: {
+                data: null,
+                loading: false,
+                loaded: false,
+                error: action.error,
+              },
+            },
+          }
+        : {
+            ...state,
+            data: null,
+            result: {
+              loading: false,
+              loaded: false,
+              error: action.error,
+            },
+          };
+    default:
+      return state;
+  }
+};
+
+export const updateFeedbackList = (state = initialState, action = {}) => {
+  switch (action.type) {
+    case `${UPDATE_FEEDBACK_LIST}_PENDING`:
+      return action.subrequest
+        ? {
+            ...state,
+            subrequests: {
+              ...state.subrequests,
+              [action.subrequest]: {
+                ...(state.subrequests[action.subrequest] || {
+                  data: null,
+                }),
+                loaded: false,
+                loading: true,
+                error: null,
+              },
+            },
+          }
+        : {
+            ...state,
+            result: {
+              loading: true,
+              loaded: false,
+              error: null,
+            },
+          };
+    case `${UPDATE_FEEDBACK_LIST}_SUCCESS`:
+      return action.subrequest
+        ? {
+            ...state,
+            subrequests: {
+              ...state.subrequests,
+              [action.subrequest]: {
+                loading: false,
+                loaded: true,
+                error: null,
+              },
+            },
+          }
+        : {
+            ...state,
+            result: {
+              loading: false,
+              loaded: true,
+              error: null,
+            },
+          };
+    case `${UPDATE_FEEDBACK_LIST}_FAIL`:
       return action.subrequest
         ? {
             ...state,

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -7,6 +7,7 @@ import {
   GET_FEEDBACKS,
   DELETE_FEEDBACK,
   RESET_DELETE_FEEDBACK,
+  UPDATE_FEEDBACK,
 } from 'volto-feedback/actions';
 
 const RESET_GET_FEEDBACK = 'RESET_GET_FEEDBACK';
@@ -373,6 +374,81 @@ export const deleteFeedback = (state = initialState, action = {}) => {
       return {
         ...initialState,
       };
+    default:
+      return state;
+  }
+};
+
+export const updateFeedback = (state = initialState, action = {}) => {
+  switch (action.type) {
+    case `${UPDATE_FEEDBACK}_PENDING`:
+      return action.subrequest
+        ? {
+            ...state,
+            subrequests: {
+              ...state.subrequests,
+              [action.subrequest]: {
+                ...(state.subrequests[action.subrequest] || {
+                  data: null,
+                }),
+                loaded: false,
+                loading: true,
+                error: null,
+              },
+            },
+          }
+        : {
+            ...state,
+            result: {
+              loading: true,
+              loaded: false,
+              error: null,
+            },
+          };
+    case `${UPDATE_FEEDBACK}_SUCCESS`:
+      return action.subrequest
+        ? {
+            ...state,
+            subrequests: {
+              ...state.subrequests,
+              [action.subrequest]: {
+                loading: false,
+                loaded: true,
+                error: null,
+              },
+            },
+          }
+        : {
+            ...state,
+            result: {
+              loading: false,
+              loaded: true,
+              error: null,
+            },
+          };
+    case `${UPDATE_FEEDBACK}_FAIL`:
+      return action.subrequest
+        ? {
+            ...state,
+            subrequests: {
+              ...state.subrequests,
+              [action.subrequest]: {
+                data: null,
+                loading: false,
+                loaded: false,
+                error: action.error,
+              },
+            },
+          }
+        : {
+            ...state,
+            data: null,
+            result: {
+              loading: false,
+              loaded: false,
+              error: action.error,
+            },
+          };
     default:
       return state;
   }


### PR DESCRIPTION
Added 'readed' flag in comments modal, to mark a comment as readed. 

<img width="1669" alt="Schermata 2024-07-18 alle 11 09 03" src="https://github.com/user-attachments/assets/06282091-672d-49c1-88be-da0f2af64fbe">

Added a badge on button to open comments modal, if there's some comment unreaded. 
<img width="1170" alt="Schermata 2024-07-18 alle 11 35 36" src="https://github.com/user-attachments/assets/f65f13ea-46ef-48ca-8136-569d1ea04e70">

Also added additionalCommentFields to config.settings['volto-feedback'] to display custom columns in feedback table


this pr needs an upgrade of his backend addon
