### PR TITLE
fix: test nonContentRoutesPublic for volto18

### DIFF
--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -133,7 +133,18 @@ export const getFeedbackEnabledNonContentRoutesPathList = () =>
 const normalizePath = (path) => path?.replace(/\?.*$/, '');
 
 export const isFeedbackEnabledForRoute = memoize((path) => {
-  if (!isCmsUi(path)) return true;
+  //test if is isNonContentRoutPublic (for volto 18)
+  const nonContentRoutesPublic = config.settings.nonContentRoutesPublic ?? [];
+  const fullPath = path.replace(/\?.*$/, '');
+  const isNonContentRoutPublic = nonContentRoutesPublic.reduce(
+    (acc, route) =>
+      acc ||
+      (nonContentRoutesPublic.includes(route) && new RegExp(route).test(path)),
+    false,
+  );
+
+  if (!isCmsUi(path) && !isNonContentRoutPublic) return true;
+
   const feedbackEnabledPaths = getFeedbackEnabledNonContentRoutesPathList();
   return feedbackEnabledPaths.some((route) => {
     const fullPath = normalizePath(path);


### PR DESCRIPTION
Testing if feedback is enable for route, consider config.settings.nonContentRoutesPublic variable defined in volto-18. 
It still work for volto-17, because nonContentRoutesPublic is considered empty by default. 